### PR TITLE
Fix/Checking if user input is empty before putting selection or word in pairs

### DIFF
--- a/lua/simple-surr/init.lua
+++ b/lua/simple-surr/init.lua
@@ -25,12 +25,18 @@ function M.setup(opts)
 
 	vim.keymap.set("v", keymaps.surround_selection, function()
 		local style = vim.fn.input("Enter surround style (e.g., [, {, (, }, ', \", `, custom): ")
-		require("simple-surr.surround").surround_selection(style)
+		-- Checking if style is empty
+		if style ~= nil and style ~= "" then
+			require("simple-surr.surround").surround_selection(style)
+		end
 	end, { desc = "Surround selection with custom or predefined style" })
 
 	vim.keymap.set("n", keymaps.surround_word, function()
 		local style = vim.fn.input("Enter surround style (e.g., [, {, (, }, ', \", `, custom): ")
-		require("simple-surr.surround").surround_word(style)
+		-- Checking if style is empty
+		if style ~= nil and style ~= "" then
+			require("simple-surr.surround").surround_word(style)
+		end
 	end, { desc = "Surround word under cursor with custom or predefined style" })
 
 	vim.keymap.set("n", "<leader>sr", function()


### PR DESCRIPTION
# Description

To check if user input is empty before calling `surround_selection()` and `surround_word()`

## The main problem

When user using `surround_selection()` or `surround_word()`, if user decided not to continue anymore, e.g. pressing `<Esc>`, the functions will continue the pairing process and putting `remove!` around user's selection/word.

Example:
```
ex_word
// process to surround_word, but the press Esc instead of choosing pair
remove!ex_wordremove!
```

Therefore, just need for a basic checking of user input to resolve the problem.